### PR TITLE
feat: Non-breaking changes for lit 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Install dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
         with:
           persist-credentials: false
-          node-version: '14'
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
         with:
           persist-credentials: false
+          node-version: '14'
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Semantic Release

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ npm install @brightspace-ui-labs/view-toggle
 <script type="module">
     import '@brightspace-ui-labs/view-toggle/view-toggle.js';
 </script>
-<d2l-view-toggle>My element</d2l-view-toggle>
+<d2l-view-toggle
+        toggleOptions='[{"text":"Bananas","val":"overall"},{"text":"Minions","val":"minios"},{"text":"Pyjamas","val":"subject"}]'
+        text="Toggle: "
+></d2l-view-toggle>
 ```
 
 ## Developing, Testing and Contributing

--- a/index.html
+++ b/index.html
@@ -7,16 +7,19 @@
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import './view-toggle.js';
 		</script>
-		<title>d2l-labs-view-toggle</title>
+		<title>d2l-view-toggle</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body>
-		<d2l-demo-page page-title="d2l-labs-view-toggle">
-			<h2>d2l-labs-view-toggle</h2>
+		<d2l-demo-page page-title="d2l-view-toggle">
+			<h2>d2l-view-toggle</h2>
 			<d2l-demo-snippet>
-				<d2l-labs-view-toggle></d2l-labs-view-toggle>
+				<d2l-view-toggle
+				toggleOptions='[{"text":"Bananas","val":"overall"},{"text":"Minions","val":"minios"},{"text":"Pyjamas","val":"subject"}]'
+				text="Toggle: "
+				></d2l-view-toggle>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/test/view-toggle.html
+++ b/test/view-toggle.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-labs-view-toggle tests</title>
+		<title>d2l-view-toggle tests</title>
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>

--- a/view-toggle.js
+++ b/view-toggle.js
@@ -1,7 +1,7 @@
-import '@brightspace-ui/core/components/icons/icon';
-import '@brightspace-ui/core/components/colors/colors';
-import { css, html, LitElement } from 'lit-element/lit-element';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 class ViewToggle extends RtlMixin(LitElement) {
 	static get properties() {


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.

Non-breaking change checklist:
- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] audit usages of `unsafeHTML` to ensure `null`, `undefined` inputs are handled as expected
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.